### PR TITLE
Fix prompt header

### DIFF
--- a/video_analyzer/prompts/frame_analysis/describe.txt
+++ b/video_analyzer/prompts/frame_analysis/describe.txt
@@ -86,7 +86,7 @@ Transitions between described frames feel natural
 Format Your Summary As:
 
 ```
-IDEO SUMMARY
+VIDEO SUMMARY
 Duration: [if provided in notes]
 
 [Opening paragraph - based on your viewed frame]


### PR DESCRIPTION
## Summary
- fix a typo in `describe.txt` so the header reads `VIDEO SUMMARY`

## Testing
- `grep -n "VIDEO SUMMARY" video_analyzer/prompts/frame_analysis/describe.txt`


------
https://chatgpt.com/codex/tasks/task_e_684c3b163f0c83259f87c4d8e31b51df